### PR TITLE
add new tab for merge sort bottom up and changed the pseudocode

### DIFF
--- a/src/algorithms/explanations/index.js
+++ b/src/algorithms/explanations/index.js
@@ -2,6 +2,7 @@ export { default as HSExp } from './HSExp.md';
 export { default as BSTExp } from './BSTExp.md';
 export { default as QSExp } from './QSExp.md';
 export { default as msort_arr_td } from './msort_arr_td.md';
+export { default as msort_arr_bup } from './msort_arr_bup.md';
 export { default as msort_lista_td } from './msort_lista_td.md';
 export { default as Prims_oldExp } from './PRIM_oldExp.md';
 export { default as PrimsExp } from './PRIMExp.md';

--- a/src/algorithms/index.js
+++ b/src/algorithms/index.js
@@ -90,7 +90,7 @@ const allalgs = {
     },
   },
   'msort_arr_td': {
-    name: 'Merge Sort',
+    name: 'Merge Sort (top down)',
     noDeploy: false,
     category: 'Sort',
     explanation: Explanation.msort_arr_td,
@@ -104,6 +104,23 @@ const allalgs = {
       sort: Controller.msort_arr_td,
     },
   },
+
+  'msort_arr_bu': {
+    name: 'Merge Sort (bottom up)',             // for bottom up
+    noDeploy: false,
+    category: 'Sort',                           // for bottom up
+    explanation: Explanation.msort_arr_bup,     // for bottom up,  working yet
+    param: <Param.msort_arr_td />,              // same as top down
+    instructions: Instructions.msort_arr_bup,    // for bottom up same as top down
+    extraInfo: ExtraInfo.msort_arr_td,          // same as top down
+    pseudocode: {
+      sort: Pseudocode.msort_arr_bup, // same as top down
+    },
+    controller: {
+      sort: Controller.msort_arr_td,// same as top down
+    },
+  },
+
   'msort_lista_td': {
     name: 'Merge Sort (lists)',
     category: 'Sort',
@@ -139,7 +156,7 @@ const allalgs = {
   'TTFTree': {
     name: '2-3-4 Tree',
     category: 'Insert/Search',
-    param: <Param.TTFTreeParam/>,
+    param: <Param.TTFTreeParam />,
     instructions: Instructions.TTFInstruction,
     explanation: Explanation.TTFExp,
     extraInfo: ExtraInfo.TTFInfo,
@@ -182,10 +199,10 @@ const allalgs = {
     },
   },
   'BFS': {
-    
+
     name: 'Breadth First Search',
     category: 'Graph',
-    param: <Param.BFSParam/>,
+    param: <Param.BFSParam />,
     instructions: Instructions.BFSInstruction,
     explanation: Explanation.BFSExp,
     extraInfo: ExtraInfo.BFSInfo,
@@ -210,8 +227,8 @@ const allalgs = {
       find: Controller.dijkstra,
 
     },
-  }, 
-   'aStar': {
+  },
+  'aStar': {
     name: 'A* (heuristic search)',
     category: 'Graph',
     param: <Param.ASTARParam />,
@@ -225,7 +242,7 @@ const allalgs = {
       find: Controller.AStar,
 
     },
-  }, 
+  },
   'prim': {
     noDeploy: false,
     name: 'Prim\'s (min. spanning tree)',

--- a/src/algorithms/instructions/index.js
+++ b/src/algorithms/instructions/index.js
@@ -62,27 +62,31 @@ const sortInstructions = [{
 }];
 
 const graphInstructions = [
-  { title: 'To Run Animation',
-  content: [
-    `Click on ${KEY_CODE} at the top of the right-hand panel`,
-    `Either step through the algorithm (click on ${KEY_FORWARD}) or play continuously (click on ${KEY_PLAY}). Code and animation will follow in lockstep.`,
-    `The graph can be chosen (see below; default Graph 1 is shown initially)`,
-    `Athoer algorithm parameters can be chosen below the
+  {
+    title: 'To Run Animation',
+    content: [
+      `Click on ${KEY_CODE} at the top of the right-hand panel`,
+      `Either step through the algorithm (click on ${KEY_FORWARD}) or play continuously (click on ${KEY_PLAY}). Code and animation will follow in lockstep.`,
+      `The graph can be chosen (see below; default Graph 1 is shown initially)`,
+      `Athoer algorithm parameters can be chosen below the
 ${KEY_PROGRESS} bar; this will reset the animation to the start`,
-    `Screen layout can be altered (depending on your browser/platform):
+      `Screen layout can be altered (depending on your browser/platform):
 the left panel can be rendered invisible by clicking
 on the arrow in its middle, the right and bottom panels can be enlarged or shrunk by dragging the ellipsis ("..."), and you can zoom in/out and drag elements in the animation panel`,
-  ]},
-  { title: 'To Choose Graph',
-  content: [
-    `The graph input panel is at the bottom and may need to be revealed
+    ]
+  },
+  {
+    title: 'To Choose Graph',
+    content: [
+      `The graph input panel is at the bottom and may need to be revealed
 by dragging the "..." up temporarily`,
-    `Under the ${KEY_PLAY} button, toggle between sample graphs (eg Graph 1) and random graphs, or`,
-    'edit text for X-Y node coordinates (this can change the graph size) and edges/weights (weights are ignored for unweighted graph algorithms), or',
-    'enter X-Y node coordinates and edges/weights in tables.',
-    `The graph size can also be explicitly increased/decreased - this generates a new random graph.`,
-    `Edge weights (for weighted graph algorithms) can be toggled between Euclidean, Manhattan and as defined explicitly in the input.`,
-  ]},
+      `Under the ${KEY_PLAY} button, toggle between sample graphs (eg Graph 1) and random graphs, or`,
+      'edit text for X-Y node coordinates (this can change the graph size) and edges/weights (weights are ignored for unweighted graph algorithms), or',
+      'enter X-Y node coordinates and edges/weights in tables.',
+      `The graph size can also be explicitly increased/decreased - this generates a new random graph.`,
+      `Edge weights (for weighted graph algorithms) can be toggled between Euclidean, Manhattan and as defined explicitly in the input.`,
+    ]
+  },
 ];
 
 const graphInstructionsTC = [{
@@ -112,6 +116,7 @@ export const BSTInstruction = bstInstructions;
 export const HSInstruction = sortInstructions;
 export const QSInstruction = sortInstructions;
 export const msort_arr_td = sortInstructions;
+export const msort_arr_bup = sortInstructions;
 export const msort_lista_td = sortInstructions;
 export const TCInstruction = graphInstructionsTC;
 export const Prims_oldInstruction = graphInstructions;

--- a/src/algorithms/pseudocode/index.js
+++ b/src/algorithms/pseudocode/index.js
@@ -3,6 +3,7 @@ export { default as binaryTreeInsertion } from './binaryTreeInsertion';
 export { default as heapSort } from './heapSort';
 export { default as quickSort } from './quickSort';
 export { default as msort_arr_td } from './msort_arr_td';
+export { default as msort_arr_bup } from './msort_arr_bup';
 export { default as msort_lista_td } from './msort_lista_td';
 export { default as transitiveClosure } from './transitiveClosure';
 export { default as prim_old } from './prim_old';


### PR DESCRIPTION
Created a new tab for "Merge sort (bottom up)" and the pseudocode has been changed for bottom up.

changes made to 
- /src/algorithms/index.js
- /src/explanations/index.js : for exporting
- /src/instructions/index.js
- /src/pseudocode/index.js

Currently this is how it looks
<img width="1434" alt="Screenshot 2024-08-14 at 11 00 45 PM" src="https://github.com/user-attachments/assets/60269574-abfc-4d43-9e6c-a8d618b74de7">
