### PR TITLE
FEAT: Implement Mask and Binary Renderer

### DIFF
--- a/src/components/DataStructures/Mask/BinaryRenderer/BinaryRenderer.module.scss
+++ b/src/components/DataStructures/Mask/BinaryRenderer/BinaryRenderer.module.scss
@@ -1,0 +1,29 @@
+@import "../../common/stylesheet/index";
+
+.container {
+    flex-direction: column;
+}
+
+.outline {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 30px;
+    min-width: 120px;
+    border: 1px solid;
+    font-size: 20px;
+    color: var(--mid-header-font);
+    background: var(--array-2d-row-col-bg);
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.title {
+    font-size: 14px;
+    color: var(--mid-header-font);
+    text-align: center;
+}
+
+.highlighted {
+    color: red;
+}

--- a/src/components/DataStructures/Mask/BinaryRenderer/index.js
+++ b/src/components/DataStructures/Mask/BinaryRenderer/index.js
@@ -1,0 +1,43 @@
+import React, { useCallback } from 'react';
+import styles from './BinaryRenderer.module.scss';
+import PropTypes from 'prop-types';
+
+const BinaryRenderer = ({ header, data, maxBits, highlight }) => {
+  const binary = useCallback(() => {
+    let binaryString = data.toString(2);
+    if (binaryString.length < maxBits) {
+      binaryString = binaryString.padStart(maxBits, '0');
+    }
+    return binaryString.split('').map((bit, index) => {
+      // If index is on highlight, return a highlighted span, else just
+      // return a normal span. Need to adjust the index as the string
+      // starts at 0, but the 0th position is the last bit
+      const adjustedIndex = binaryString.length - index - 1;
+      return (
+        <span key={index} className={highlight.includes(adjustedIndex) ? styles.highlighted : ""}>
+          {bit}
+        </span>
+      );
+    });
+  }, [data, maxBits, highlight]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.outline}>
+        {binary()}
+      </div>
+      <div className={styles.title}>
+        {header}
+      </div>
+    </div>
+  );
+}
+
+BinaryRenderer.propTypes = ({
+  header: PropTypes.string.isRequired,
+  data: PropTypes.number.isRequired,
+  maxBits: PropTypes.number,
+  highlight: PropTypes.array,
+});
+
+export default BinaryRenderer;

--- a/src/components/DataStructures/Mask/MaskRenderer/MaskRenderer.module.scss
+++ b/src/components/DataStructures/Mask/MaskRenderer/MaskRenderer.module.scss
@@ -1,0 +1,8 @@
+@import "../../common/stylesheet/index";
+
+.container {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: row;
+    gap: 25px;
+}

--- a/src/components/DataStructures/Mask/MaskRenderer/index.js
+++ b/src/components/DataStructures/Mask/MaskRenderer/index.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import Renderer from '../../common/Renderer';
+import styles from './MaskRenderer.module.scss';
+import BinaryRenderer from '../BinaryRenderer';
+
+class MaskRenderer extends Renderer {
+  constructor(props) {
+    super(props)
+    this.centerX = 0;
+    this.centerY = 0;
+    this.zoom = 100;
+    this.elementRef = React.createRef();
+    this.togglePan(true);
+    this.toggleZoom(true);
+  }
+
+  renderData() {
+    const { binaryData, maskData, maxBits, highlight } = this.props.data;
+    return (
+      <div className={styles.container}>
+        <BinaryRenderer
+          header={"Binary Rep"}
+          data={binaryData}
+          maxBits={maxBits}
+          highlight={highlight}
+        />
+        <BinaryRenderer
+          header={"Mask"}
+          data={maskData}
+          maxBits={maxBits}
+          highlight={highlight}
+        />
+      </div>
+    );
+  }
+}
+
+export default MaskRenderer;

--- a/src/components/DataStructures/Mask/MaskTracer.js
+++ b/src/components/DataStructures/Mask/MaskTracer.js
@@ -1,0 +1,32 @@
+// eslint-disable-next-line import/no-unresolved
+import Tracer from '../common/Tracer';
+import MaskRenderer from './MaskRenderer/index';
+
+class MaskTracer extends Tracer {
+  getRendererClass() {
+    return MaskRenderer;
+  }
+
+  init() {
+    super.init();
+    this.maxBits = 0;
+    this.binaryData = 0;
+    this.maskData = 0;
+    this.highlight = [];
+  }
+
+  setMaxBits(bits) {
+    this.maxBits = bits;
+  }
+
+  setBinary(data) {
+    this.binaryData = data;
+  }
+
+  setMask(maskDecimal, maskIndex) {
+    this.maskData = maskDecimal;
+    this.highlight = typeof maskIndex === "number" ? [maskIndex] : maskIndex;
+  }
+}
+
+export default MaskTracer;


### PR DESCRIPTION
# New Renderers!  🚀 
A pre-emptive feature to be used in the implementations of Straight Radix Sort and MSD Radix Sort. This is part 1 of future pull requests to implement SRS and MSD radix sorts.

## Mask Renderer 😷 
Highlights the current masked bit of a value.

## Binary Renderer 💯 
Highlights the currently selected bit of a binary representation of a number.

https://github.com/user-attachments/assets/850f9bb4-9938-4c11-95e2-d74af80e76eb

